### PR TITLE
Allow more generic usage of chart widget

### DIFF
--- a/examples/split-chart.rs
+++ b/examples/split-chart.rs
@@ -31,8 +31,8 @@ extern crate iced;
 extern crate plotters;
 
 use iced::{
-    executor, Align, Application, Clipboard, Column, Command, Container, Element, Font, Length,
-    Settings, Subscription,
+    executor, Align, Application, Clipboard, Column, Command, Container, Element, Length, Settings,
+    Subscription,
 };
 use plotters::{coord::Shift, prelude::*};
 use plotters_backend::DrawingBackend;

--- a/src/chart.rs
+++ b/src/chart.rs
@@ -16,6 +16,32 @@ use plotters_backend::DrawingBackend;
 #[cfg(target_arch = "wasm32")]
 use dummy::*;
 
+impl<Message, C> Chart<Message> for &mut C
+where
+    C: Chart<Message>,
+{
+    fn build_chart<DB: DrawingBackend>(&self, builder: ChartBuilder<DB>) {
+        C::build_chart(self, builder)
+    }
+
+    fn draw_chart<DB: DrawingBackend>(&self, root: DrawingArea<DB, Shift>) {
+        C::draw_chart(self, root)
+    }
+
+    fn draw<F: Fn(&mut Frame)>(&self, size: Size, f: F) -> Geometry {
+        C::draw(self, size, f)
+    }
+
+    fn update(
+        &mut self,
+        event: Event,
+        bounds: Rectangle,
+        cursor: Cursor,
+    ) -> (Status, Option<Message>) {
+        C::update(self, event, bounds, cursor)
+    }
+}
+
 /// Chart View Model
 ///
 /// use it with [`ChartWidget`].
@@ -65,6 +91,7 @@ pub trait Chart<Message> {
     ///          }
     ///      }
     /// }
+    /// ```
     #[inline]
     fn draw_chart<DB: DrawingBackend>(&self, root: DrawingArea<DB, Shift>) {
         let builder = ChartBuilder::on(&root);

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,7 +5,7 @@
 // License: MIT
 
 #[derive(Debug)]
-/// Indicates that some error occured within the Iced backend
+/// Indicates that some error occurred within the Iced backend
 pub enum Error {}
 
 impl std::fmt::Display for Error {

--- a/src/native/backend/mod.rs
+++ b/src/native/backend/mod.rs
@@ -170,11 +170,12 @@ where
         if style.color().alpha == 0.0 {
             return Ok(());
         }
+
+        let circle = canvas::Path::circle(center.cvt_point(), radius as f32);
+
         if fill {
-            let circle = canvas::Path::circle(center.cvt_point(), radius as f32);
             self.frame.fill(&circle, cvt_color(&style.color()));
         } else {
-            let circle = canvas::Path::circle(center.cvt_point(), radius as f32);
             self.frame.stroke(&circle, cvt_stroke(style));
         }
 

--- a/src/native/backend/triangulate/mod.rs
+++ b/src/native/backend/triangulate/mod.rs
@@ -41,7 +41,7 @@ pub(crate) struct Polygon {
     ll: *mut c_void,
 }
 
-pub(crate) struct CDT {
+pub(crate) struct Cdt {
     ll: *mut c_void,
 }
 
@@ -49,7 +49,7 @@ pub(crate) struct TriangleVec {
     ll: *mut c_void,
 
     #[allow(dead_code)]
-    cdt: CDT,
+    cdt: Cdt,
 }
 
 #[derive(Copy, Clone, PartialEq)]
@@ -94,10 +94,10 @@ impl Drop for Polygon {
     }
 }
 
-impl CDT {
-    pub(crate) fn new(polygon: Polygon) -> CDT {
+impl Cdt {
+    pub(crate) fn new(polygon: Polygon) -> Cdt {
         unsafe {
-            let rv = CDT {
+            let rv = Cdt {
                 ll: p2t_cdt_new(polygon.ll),
             };
 
@@ -118,7 +118,7 @@ impl CDT {
     }
 }
 
-impl Drop for CDT {
+impl Drop for Cdt {
     fn drop(&mut self) {
         unsafe {
             p2t_cdt_free(self.ll);
@@ -164,5 +164,5 @@ pub(crate) fn triangulate_points<'a, I>(points: I) -> TriangleVec
 where
     I: Iterator<Item = &'a [Scalar; 2]>,
 {
-    CDT::new(Polygon::from_iterator(points)).triangulate()
+    Cdt::new(Polygon::from_iterator(points)).triangulate()
 }

--- a/src/native/backend/utils/path.rs
+++ b/src/native/backend/utils/path.rs
@@ -36,12 +36,12 @@ impl<I: Iterator<Item = PathSimplifierPointInner>> Iterator for PathSimplifier<I
 
     fn next(&mut self) -> Option<Self::Item> {
         // Branch to source points iterator (exhaust next group)
-        while let Some(point) = self.source_points.next() {
+        for point in &mut self.source_points {
+            // Retain current point as 'last point'
+            self.last_point = Some(point);
+
             // Backtrack in points
             if let Some(point_before) = self.last_point {
-                // Retain current point as 'last point'
-                self.last_point = Some(point);
-
                 // De-duplicate points
                 if point_before != point {
                     let mut do_yield = false;
@@ -100,9 +100,6 @@ impl<I: Iterator<Item = PathSimplifierPointInner>> Iterator for PathSimplifier<I
                         return Some([point_before[0] as f64, point_before[1] as f64]);
                     }
                 }
-            } else {
-                // Retain first point as 'last point'
-                self.last_point = Some(point);
             }
         }
 

--- a/src/native/graphics.rs
+++ b/src/native/graphics.rs
@@ -12,7 +12,7 @@ use iced_native::{event, mouse::Interaction, Font, Point, Rectangle, Vector};
 use plotters::prelude::DrawingArea;
 use plotters_backend::{FontFamily, FontStyle};
 
-pub type ChartWidget<'a, Message, C> = super::native::ChartWidget<'a, Message, C>;
+pub type ChartWidget<Message, C> = super::native::ChartWidget<Message, C>;
 
 impl<B: Backend + backend::Text> ChartRenderer for Renderer<B> {
     fn draw_chart<Message, C>(


### PR DESCRIPTION
Commit af59edc1b673a86656aadd95ae3980503f4e7323 addresses the following lints:
- [upper_case_acronyms](https://rust-lang.github.io/rust-clippy/master/#upper_case_acronyms)
- [while_let_on_iterator](https://rust-lang.github.io/rust-clippy/master/#while_let_on_iterator)
- [branches_sharing_code](https://rust-lang.github.io/rust-clippy/master/#branches_sharing_code)

Commit dabfd8db95b2f54dd708377e465eaca0f5f45dff and 3983f42c070099a2d08e6e13bb41dbc2ee149442 fix other small pedantic things I noticed while making other changes.

The meat of the change is in commit b95f26823e40b39dec156c1c74f6231fcdb615e2. This commit does not restrict the chart passed to the `ChartWidget` to a `&mut` reference to something that implements `Chart`. This commit instead allows the `ChartWidget` to be generic over any type that implements `Chart` and also adds a blanket implementation over all `&mut T where T: Chart`. These two changes in conjunction allow for the `ChartWidget` to take either a mutable reference to or ownership of a type that implements `Chart`.

The previous implementation of `ChartWidget` to always take a `&mut Chart` makes sense in most use cases since the user is most likely to create a struct to hold persistent data about the chart and pass a mutable reference to that to the chart widget in the `view` method on the `iced::Application`. My use-case however required that I pass extra data to all of the charts in the update function. To accomplish this, I needed to return a new structure with the new data that will implement Chart, but this was not possible since the `ChartWidget` implementation required a reference to this temporary structure that could not persist.

I have not thoroughly tested the change in implementation to ensure it will not break any existing code though my idea was to ensure this would be 100% backwards compatible with the previous implementation. I have tested the implementation on both of the native examples.

I did not implement this change on the web implementation due to my lack of familiarity with its implementation and the implementation seeming reliant on the chart passed as a reference as seen here:

https://github.com/Joylei/plotters-iced/blob/master/src/web/widget.rs#L97