### PR TITLE
Changes to allow the ChartWidget to be used in pure applications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ plotters = { version = "0.3", default_features = false }
 plotters-backend = "0.3"
 iced_native = "0.5"
 iced_graphics = { version = "0.3", features = ["canvas"] }
+iced = { version = "0.4.2", features = ["pure"], default_features = false, optional = true }
+iced_pure = { version = "0.2.2", optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 num-traits = "0.2"
@@ -36,8 +38,13 @@ plotters = { version = "0.3", default_features = false, features = [
     "line_series",
     "point_series",
 ] }
-iced = { version = "0.4", features = ["canvas", "tokio"] }
+iced = { version = "0.4.2", features = ["canvas", "tokio", "pure"] }
 chrono = { version = "0.4", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 sysinfo = { version = "0.23", default_features = false }
+
+[features]
+default = ["native"]
+pure = ["iced", "iced_pure"]
+native = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,9 @@
 */
 #![warn(missing_docs)]
 
+#[cfg(all(feature = "native", feature = "pure"))]
+compile_error!("feature \"native\" and feature \"pure\" cannot be enabled at the same time");
+
 pub extern crate plotters_backend;
 mod chart;
 mod error;


### PR DESCRIPTION
By enabling and disabling the pure and native features for this crate, the ChartWidget can be either used in impure applications or pure applications. 