### PR TITLE
bump iced versions to 0.5 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "plotters-iced"
-version = "0.4.0"
+version = "0.5.0"
 description = "Iced backend for Plotters"
 readme = "README.md"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ members = [".", "examples/split-chart"]
 [dependencies]
 plotters = { version = "0.3", default_features = false }
 plotters-backend = "0.3"
-iced_native = { version = "0.5", git = "https://github.com/iced-rs/iced.git" }
-iced_graphics = { version = "0.3", features = [
+iced_native = { version = "0.6", git = "https://github.com/iced-rs/iced.git" }
+iced_graphics = { version = "0.4", features = [
     "canvas",
 ], git = "https://github.com/iced-rs/iced.git" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ members = [".", "examples/split-chart"]
 [dependencies]
 plotters = { version = "0.3", default_features = false }
 plotters-backend = "0.3"
-iced_native = { version = "0.6", git = "https://github.com/iced-rs/iced.git" }
+iced_native = { version = "0.6" }
 iced_graphics = { version = "0.4", features = [
     "canvas",
-], git = "https://github.com/iced-rs/iced.git" }
+] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 num-traits = "0.2"
@@ -38,10 +38,10 @@ plotters = { version = "0.3", default_features = false, features = [
     "line_series",
     "point_series",
 ] }
-iced = { version = "*", features = [
+iced = { version = "0.5", features = [
     "canvas",
     "tokio",
-], git = "https://github.com/iced-rs/iced.git" }
+] }
 chrono = { version = "0.4", default-features = false }
 rand = "0.8"
 tokio = { version = "1", features = ["rt"], default-features = false }

--- a/examples/split-chart/Cargo.toml
+++ b/examples/split-chart/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-iced = { version = "0.4", features = [
+iced = { version = "0.5", features = [
     "canvas",
     "tokio",
 ], git = "https://github.com/iced-rs/iced.git" }


### PR DESCRIPTION
Bump `iced_native` to `0.6` and `iced_graphics` to `0.4` to support `iced` version `0.5`.