### PR TITLE
Add  user defined Theme support to plotters_iced::renderer::Renderer trait.

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -7,7 +7,7 @@
 use crate::backend::IcedChartBackend;
 use crate::Chart;
 use iced_graphics::{self, backend, Backend, Primitive, Vector};
-use iced_native::{Font, Layout, Theme};
+use iced_native::{Font, Layout};
 use plotters::prelude::DrawingArea;
 use plotters_backend::{FontFamily, FontStyle};
 
@@ -23,7 +23,7 @@ pub trait Renderer: iced_native::Renderer + iced_native::text::Renderer {
         F: Fn(FontFamily, FontStyle) -> Font;
 }
 
-impl<B: Backend + backend::Text> Renderer for iced_graphics::Renderer<B, Theme> {
+impl<B: Backend + backend::Text, Theme> Renderer for iced_graphics::Renderer<B, Theme> {
     fn draw_chart<Message, C, F>(
         &mut self,
         state: &C::State,


### PR DESCRIPTION
I was unable to compile using a Theme that I defined myself instead of using `iced_style::Theme` which was added in iced 0.5.

```
error[E0277]: the trait bound `iced_graphics::renderer::Renderer<iced_glow::backend::Backend, MyTheme>: plotters_iced::renderer::Renderer` is not satisfied
   --> src/panel/pqn.rs:698:9
    |
698 | /         plotters_iced::ChartWidget::new(self)
699 | |             .width(iced::Length::Units(40))
700 | |             .height(iced::Length::Fill)
    | |_______________________________________^ the trait `plotters_iced::renderer::Renderer` is not implemented for `iced_graphics::renderer::Renderer<iced_glow::backend::Backend, MyTheme>`
701 |               .into()
    |                ---- required by a bound introduced by this call
    |
    = help: the trait `plotters_iced::renderer::Renderer` is implemented for `iced_graphics::renderer::Renderer<B, iced::Theme>`
    = note: required for `iced_native::Element<'_, Message, iced_graphics::renderer::Renderer<iced_glow::backend::Backend, MyTheme>>` to implement `From<ChartWidget<'_, Message, iced_graphics::renderer::Renderer<iced_glow::backend::Backend, MyTheme>, &LegendWidget>>`
    = note: required for `ChartWidget<'_, Message, iced_graphics::renderer::Renderer<iced_glow::backend::Backend, MyTheme>, &LegendWidget>` to implement `std::convert::Into<iced_native::Element<'_, Message, iced_graphics::renderer::Renderer<iced_glow::backend::Backend, MyTheme>>>`
```

The reason is that the `plotters_iced::renderer::Renderer` trait is limited to implement for `iced_graphics::Renderer<B, iced_style::Theme>`.

In the patch, the concrete type `iced_style::Theme` was changed to a type parameter.