### PR TITLE
Configured dependabot to keep dependencies up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: "daily"
+  target-branch: "master"


### PR DESCRIPTION
Dependabot will check if your dependencies are up to date on a daily basis, opening PRs if one or more are outdated.

This can be helpful to be notified when a new version of iced is released.

You can also manually run dependabot from insights > dependency graph > dependabot.