### PR TITLE
Shrink the column to fit contents in CPU monitor example

### DIFF
--- a/examples/cpu-monitor.rs
+++ b/examples/cpu-monitor.rs
@@ -181,7 +181,7 @@ impl SystemChart {
                 .vertical_alignment(Vertical::Center)
                 .into()
         } else {
-            let mut col = Column::new().width(Length::Fill).height(Length::Fill);
+            let mut col = Column::new().width(Length::Fill).height(Length::Shrink);
 
             let chart_height = self.chart_height;
             let mut idx = 0;


### PR DESCRIPTION
This small change prevents the scrollbar from trying to fit an infinitely high column (which does not seem desirable).
Before:
![Screenshot 2023-03-12 at 11 32 13](https://user-images.githubusercontent.com/20155974/224539129-75d394df-3c33-4767-b3d1-2bfc9dde6c14.png)

After this change:
![Screenshot 2023-03-12 at 11 32 46](https://user-images.githubusercontent.com/20155974/224539141-071c2c54-7681-4cbc-8ad9-895a140331a6.png)
