### PR TITLE
Fix references to make rustdoc build the docs again

### DIFF
--- a/src/chart.rs
+++ b/src/chart.rs
@@ -105,9 +105,9 @@ pub trait Chart<Message> {
         self.build_chart(state, builder);
     }
 
-    /// draw on [`iced_graphics::canvas::Canvas`]
+    /// draw on [`iced_graphics::widget::canvas::Canvas`]
     ///
-    /// override this method if you want to use [`iced_graphics::canvas::Cache`]
+    /// override this method if you want to use [`iced_graphics::widget::canvas::Cache`]
     ///
     /// ## Example
     /// ```rust,ignore


### PR DESCRIPTION
Currently the docs on docs.rs are failing. This PR should fix that.