### PR TITLE
split-chart example also migrates to iced 0.9

### DIFF
--- a/examples/split-chart/Cargo.toml
+++ b/examples/split-chart/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-iced = { version = "0.8", features = ["canvas", "tokio"] }
+iced = { version = "0.9", features = ["canvas", "tokio"] }
 plotters-iced = { path = "../../" }
 plotters = { version = "0.3", default_features = false, features = [
     "chrono",


### PR DESCRIPTION
Split-chart example fails to compile due to iced_core version mismatch. Then I fixed it.

```
error[E0308]: mismatched types
   --> examples/split-chart/src/main.rs:115:20
    |
115 |             .width(Length::Fill)
    |              ----- ^^^^^^^^^^^^ expected `iced_core::length::Length`, found `Length`
    |              |
    |              arguments to this method are incorrect
    |
    = note: `Length` and `iced_core::length::Length` have similar names, but are actually distinct types
note: `Length` is defined in crate `iced_core`
   --> /home/yuma/.cargo/registry/src/index.crates.io-6f17d22bba15001f/iced_core-0.8.1/src/length.rs:3:1
    |
3   | pub enum Length {
    | ^^^^^^^^^^^^^^^
note: `iced_core::length::Length` is defined in crate `iced_core`
   --> /home/yuma/.cargo/registry/src/index.crates.io-6f17d22bba15001f/iced_core-0.9.0/src/length.rs:3:1
    |
3   | pub enum Length {
    | ^^^^^^^^^^^^^^^
    = note: perhaps two different versions of crate `iced_core` are being used?
```

ref: https://github.com/Joylei/plotters-iced/pull/21
