### PR TITLE
Migrate to Rust 2024 and to iced 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "plotters-iced"
-version = "0.11.0"
+version = "0.12.0"
 description = "Iced backend for Plotters"
 readme = "README.md"
 license = "MIT"
-edition = "2021"
+edition = "2024"
 resolver = "2"
 homepage = "https://github.com/Joylei/plotters-iced"
 repository = "https://github.com/Joylei/plotters-iced.git"
@@ -19,8 +19,8 @@ members = [".", "examples/split-chart"]
 [dependencies]
 plotters = { version = "0.3", default-features = false }
 plotters-backend = "0.3"
-iced_widget = { version = "0.13", features = ["canvas"] }
-iced_graphics = "0.13"
+iced_widget = { version = "0.14", features = ["canvas"] }
+iced_graphics = "0.14"
 once_cell = "1"
 
 [dev-dependencies]
@@ -30,7 +30,7 @@ plotters = { version = "0.3", default-features = false, features = [
     "line_series",
     "point_series",
 ] }
-iced = { version = "0.13", features = ["canvas", "tokio"] }
+iced = { version = "0.14", features = ["canvas", "tokio"] }
 chrono = { version = "0.4", default-features = false }
 rand = "0.8"
 tokio = { version = "1", features = ["rt"], default-features = false }

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Include `plotters-iced` in your `Cargo.toml` dependencies:
 
 ```toml
 [dependencies]
-plotters-iced = "0.11"
-iced = { version = "0.13", features = ["canvas", "tokio"] }
+plotters-iced = "0.12"
+iced = { version = "0.14", features = ["canvas", "tokio"] }
 plotters="0.3"
 ```
 

--- a/examples/cpu-monitor.rs
+++ b/examples/cpu-monitor.rs
@@ -28,7 +28,7 @@ use std::{
 use sysinfo::{CpuRefreshKind, RefreshKind, System};
 
 const PLOT_SECONDS: usize = 60; //1 min
-const TITLE_FONT_SIZE: u16 = 22;
+const TITLE_FONT_SIZE: u32 = 22;
 const SAMPLE_EVERY: Duration = Duration::from_millis(1000);
 
 const FONT_BOLD: Font = Font {
@@ -38,14 +38,15 @@ const FONT_BOLD: Font = Font {
 };
 
 fn main() {
-    iced::application("CPU Monitor Example", State::update, State::view)
+    iced::application(State::new, State::update, State::view)
+        .title("CPU Monitor Example")
         .antialiasing(true)
         .default_font(Font::with_name("Noto Sans"))
         .subscription(|_| {
             const FPS: u64 = 50;
             iced::time::every(Duration::from_millis(1000 / FPS)).map(|_| Message::Tick)
         })
-        .run_with(State::new)
+        .run()
         .unwrap();
 }
 
@@ -165,7 +166,7 @@ impl SystemChart {
         }
     }
 
-    fn view(&self) -> Element<Message> {
+    fn view(&self) -> Element<'_, Message> {
         if !self.is_initialized() {
             Text::new("Loading...")
                 .align_x(Horizontal::Center)
@@ -191,7 +192,7 @@ impl SystemChart {
                     idx += 1;
                 }
                 while idx % self.items_per_row != 0 {
-                    row = row.push(Space::new(Length::Fill, Length::Fixed(50.0)));
+                    row = row.push(Space::new().width(Length::Fill).height(Length::Fixed(50.0)));
                     idx += 1;
                 }
                 col = col.push(row);
@@ -234,7 +235,7 @@ impl CpuUsageChart {
         self.cache.clear();
     }
 
-    fn view(&self, idx: usize, chart_height: f32) -> Element<Message> {
+    fn view(&self, idx: usize, chart_height: f32) -> Element<'_, Message> {
         Column::new()
             .width(Length::Fill)
             .height(Length::Shrink)

--- a/examples/cpu-monitor.rs
+++ b/examples/cpu-monitor.rs
@@ -10,13 +10,13 @@ extern crate sysinfo;
 
 use chrono::{DateTime, Utc};
 use iced::{
+    Alignment, Element, Font, Length, Size, Task,
     alignment::{Horizontal, Vertical},
     font,
     widget::{
-        canvas::{Cache, Frame, Geometry},
         Column, Container, Row, Scrollable, Space, Text,
+        canvas::{Cache, Frame, Geometry},
     },
-    Alignment, Element, Font, Length, Size, Task,
 };
 use plotters::prelude::ChartBuilder;
 use plotters_backend::DrawingBackend;

--- a/examples/large-data.rs
+++ b/examples/large-data.rs
@@ -11,18 +11,17 @@ extern crate tokio;
 
 use chrono::{DateTime, Utc};
 use iced::{
-    font,
+    Alignment, Element, Font, Length, Size, Task, font,
     widget::{
-        canvas::{Cache, Frame, Geometry},
         Column, Container, Text,
+        canvas::{Cache, Frame, Geometry},
     },
-    Alignment, Element, Font, Length, Size, Task,
 };
 use plotters::prelude::ChartBuilder;
 use plotters_backend::DrawingBackend;
 use plotters_iced::{
-    sample::lttb::{DataPoint, LttbSource},
     Chart, ChartWidget, Renderer,
+    sample::lttb::{DataPoint, LttbSource},
 };
 use rand::Rng;
 use std::time::Duration;

--- a/examples/large-data.rs
+++ b/examples/large-data.rs
@@ -27,7 +27,7 @@ use rand::Rng;
 use std::time::Duration;
 use std::{collections::VecDeque, time::Instant};
 
-const TITLE_FONT_SIZE: u16 = 22;
+const TITLE_FONT_SIZE: u32 = 22;
 
 const FONT_BOLD: Font = Font {
     family: font::Family::Name("Noto Sans"),
@@ -36,10 +36,11 @@ const FONT_BOLD: Font = Font {
 };
 
 fn main() {
-    iced::application("Large Data Example", State::update, State::view)
+    iced::application(State::new, State::update, State::view)
+        .title("Large Data Example")
         .antialiasing(true)
         .default_font(Font::with_name("Noto Sans"))
-        .run_with(State::new)
+        .run()
         .unwrap();
 }
 
@@ -144,7 +145,7 @@ impl ExampleChart {
         }
     }
 
-    fn view(&self) -> Element<Message> {
+    fn view(&self) -> Element<'_, Message> {
         let chart = ChartWidget::new(self)
             .width(Length::Fill)
             .height(Length::Fill);

--- a/examples/mouse_events.rs
+++ b/examples/mouse_events.rs
@@ -25,6 +25,10 @@ struct State {
 }
 
 impl State {
+    fn new() -> Self {
+        Self::default()
+    }
+
     fn update(&mut self, message: Message) {
         match message {
             Message::MouseEvent(event, point) => {
@@ -44,7 +48,7 @@ impl State {
         }
     }
 
-    fn view(&self) -> Element<Message> {
+    fn view(&self) -> Element<'_, Message> {
         let content = Column::new()
             .spacing(20)
             .width(Length::Fill)
@@ -74,7 +78,7 @@ struct ArtChart {
 }
 
 impl ArtChart {
-    fn view(&self) -> Element<Message> {
+    fn view(&self) -> Element<'_, Message> {
         let chart = ChartWidget::new(self)
             .width(Length::Fill)
             .height(Length::Fill);
@@ -211,7 +215,7 @@ impl Chart<Message> for ArtChart {
     fn update(
         &self,
         _state: &mut Self::State,
-        event: canvas::Event,
+        event: &iced::Event,
         bounds: iced::Rectangle,
         cursor: Cursor,
     ) -> (event::Status, Option<Message>) {
@@ -222,7 +226,7 @@ impl Chart<Message> for ArtChart {
                     let p = point - p_origin;
                     return (
                         event::Status::Captured,
-                        Some(Message::MouseEvent(evt, Point::new(p.x, p.y))),
+                        Some(Message::MouseEvent(evt.clone(), Point::new(p.x, p.y))),
                     );
                 }
                 _ => {}
@@ -238,7 +242,8 @@ enum Message {
 }
 
 fn main() -> iced::Result {
-    iced::application("Art", State::update, State::view)
+    iced::application(State::new, State::update, State::view)
+        .title("Art")
         .antialiasing(true)
         .run()
 }

--- a/examples/mouse_events.rs
+++ b/examples/mouse_events.rs
@@ -5,16 +5,15 @@
 // License: MIT
 
 use iced::{
-    event,
+    Alignment, Element, Length, Point, Size, event,
     mouse::Cursor,
     widget::{
-        canvas::{self, Cache, Frame, Geometry},
         Column, Container, Text,
+        canvas::{self, Cache, Frame, Geometry},
     },
-    Alignment, Element, Length, Point, Size,
 };
 use plotters::{
-    coord::{types::RangedCoordf32, ReverseCoordTranslate},
+    coord::{ReverseCoordTranslate, types::RangedCoordf32},
     prelude::*,
 };
 use plotters_iced::{Chart, ChartWidget, Renderer};

--- a/examples/split-chart/Cargo.toml
+++ b/examples/split-chart/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-iced = { version = "0.13", features = ["canvas"] }
+iced = { version = "0.14", features = ["canvas"] }
 plotters-iced = { path = "../../" }
 plotters = { version = "0.3", default-features = false, features = [
     "chrono",
@@ -16,7 +16,7 @@ plotters = { version = "0.3", default-features = false, features = [
 ] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-iced.version = "0.13"
+iced.version = "0.14"
 iced.features = ["canvas", "debug", "webgl"]
 
 console_error_panic_hook = "0.1"

--- a/examples/split-chart/src/main.rs
+++ b/examples/split-chart/src/main.rs
@@ -41,7 +41,8 @@ fn main() {
         console_log::init().expect("Initialize logger");
         std::panic::set_hook(Box::new(console_error_panic_hook::hook));
     }
-    let app = iced::application("Split Chart Example", State::update, State::view)
+    let app = iced::application(State::new, State::update, State::view)
+        .title("Split Chart Example")
         .antialiasing(cfg!(not(target_arch = "wasm32")))
         .subscription(|_| window::frames().map(|_| Message::Tick));
     app.run().unwrap();
@@ -59,6 +60,10 @@ struct State {
 }
 
 impl State {
+    fn new() -> Self {
+        Self::default()
+    }
+
     fn update(&mut self, _message: Message) {}
 
     fn view(&self) -> Element<'_, Message> {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -4,7 +4,10 @@
 // Copyright: 2022, Joylei <leingliu@gmail.com>
 // License: MIT
 
+use crate::error::Error;
+use crate::utils::{CvtPoint, cvt_color, cvt_stroke};
 use iced_graphics::core::text::Paragraph;
+use iced_widget::text::LineHeight;
 use iced_widget::{
     canvas,
     core::{Font, Size, alignment::Vertical, font, text},
@@ -26,9 +29,6 @@ use plotters_backend::{
 };
 use std::collections::HashSet;
 
-use crate::error::Error;
-use crate::utils::{CvtPoint, cvt_color, cvt_stroke};
-
 /// The Iced drawing backend
 pub(crate) struct IcedChartBackend<'a, B> {
     frame: &'a mut canvas::Frame,
@@ -49,7 +49,7 @@ where
     }
 }
 
-impl<'a, B> DrawingBackend for IcedChartBackend<'a, B>
+impl<B> DrawingBackend for IcedChartBackend<'_, B>
 where
     B: text::Renderer<Font = Font>,
 {
@@ -224,7 +224,7 @@ where
             max_width: f32::INFINITY,
             color: cvt_color(&style.color()),
             size: (style.size() as f32).into(),
-            line_height: Default::default(),
+            line_height: LineHeight::default(),
             font,
             align_x,
             align_y,
@@ -277,7 +277,7 @@ where
             content: text,
             bounds,
             size: self.backend.default_size(),
-            line_height: Default::default(),
+            line_height: LineHeight::default(),
             font,
             align_x,
             align_y,

--- a/src/chart.rs
+++ b/src/chart.rs
@@ -5,12 +5,11 @@
 // License: MIT
 
 use iced_widget::canvas::Cache;
-use iced_widget::core::event::Status;
-use iced_widget::core::mouse::Interaction;
 use iced_widget::core::Rectangle;
+use iced_widget::core::mouse::Interaction;
 use iced_widget::{
     canvas::{Event, Frame, Geometry},
-    core::{mouse::Cursor, Size},
+    core::{Size, mouse::Cursor},
 };
 use plotters::{chart::ChartBuilder, coord::Shift, drawing::DrawingArea};
 use plotters_backend::DrawingBackend;
@@ -45,10 +44,10 @@ where
     fn update(
         &self,
         state: &mut Self::State,
-        event: Event,
+        event: &Event,
         bounds: Rectangle,
         cursor: Cursor,
-    ) -> (Status, Option<Message>) {
+    ) -> Option<Message> {
         C::update(self, state, event, bounds, cursor)
     }
     #[inline]
@@ -148,11 +147,11 @@ pub trait Chart<Message> {
     fn update(
         &self,
         state: &mut Self::State,
-        event: Event,
+        event: &Event,
         bounds: Rectangle,
         cursor: Cursor,
-    ) -> (Status, Option<Message>) {
-        (Status::Ignored, None)
+    ) -> Option<Message> {
+        None
     }
 
     /// Returns the current mouse interaction of the [`Chart`]

--- a/src/chart.rs
+++ b/src/chart.rs
@@ -4,6 +4,7 @@
 // Copyright: 2022, Joylei <leingliu@gmail.com>
 // License: MIT
 
+use iced_graphics::core::event::Status;
 use iced_widget::canvas::Cache;
 use iced_widget::core::Rectangle;
 use iced_widget::core::mouse::Interaction;
@@ -47,7 +48,7 @@ where
         event: &Event,
         bounds: Rectangle,
         cursor: Cursor,
-    ) -> Option<Message> {
+    ) -> (Status, Option<Message>) {
         C::update(self, state, event, bounds, cursor)
     }
     #[inline]
@@ -150,8 +151,8 @@ pub trait Chart<Message> {
         event: &Event,
         bounds: Rectangle,
         cursor: Cursor,
-    ) -> Option<Message> {
-        None
+    ) -> (Status, Option<Message>) {
+        (Status::Ignored, None)
     }
 
     /// Returns the current mouse interaction of the [`Chart`]

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -11,8 +11,8 @@ use iced_widget::{
 };
 use plotters::prelude::DrawingArea;
 
-use crate::backend::IcedChartBackend;
 use crate::Chart;
+use crate::backend::IcedChartBackend;
 
 /// Graphics Renderer
 pub trait Renderer:

--- a/src/sample/lttb.rs
+++ b/src/sample/lttb.rs
@@ -116,7 +116,7 @@ where
     }
 }
 
-impl<'a, S: LttbSource> LttbSource for &'a S {
+impl<S: LttbSource> LttbSource for &S {
     type Item = S::Item;
     #[inline]
     fn len(&self) -> usize {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -8,22 +8,6 @@ use iced_widget::canvas;
 use iced_widget::core::{Color, Point};
 use plotters_backend::{BackendColor, BackendCoord, BackendStyle};
 
-pub(crate) trait AndExt {
-    fn and<F: Fn(Self) -> Self>(self, f: F) -> Self
-    where
-        Self: Sized;
-}
-
-impl<T> AndExt for T {
-    #[inline(always)]
-    fn and<F: Fn(Self) -> Self>(self, f: F) -> Self
-    where
-        Self: Sized,
-    {
-        f(self)
-    }
-}
-
 #[inline]
 pub(crate) fn cvt_color(color: &BackendColor) -> Color {
     let ((r, g, b), a) = (color.rgb, color.alpha);
@@ -31,7 +15,7 @@ pub(crate) fn cvt_color(color: &BackendColor) -> Color {
 }
 
 #[inline]
-pub(crate) fn cvt_stroke<S: BackendStyle>(style: &S) -> canvas::Stroke {
+pub(crate) fn cvt_stroke<S: BackendStyle>(style: &S) -> canvas::Stroke<'_> {
     canvas::Stroke::default()
         .with_color(cvt_color(&style.color()))
         .with_width(style.stroke_width() as f32)

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -9,11 +9,10 @@ use core::marker::PhantomData;
 use iced_widget::{
     canvas::Event,
     core::{
-        event,
+        Element, Layout, Length, Rectangle, Shell, Size, Widget,
         mouse::Cursor,
         renderer::Style,
-        widget::{tree, Tree},
-        Element, Layout, Length, Rectangle, Shell, Size, Widget,
+        widget::{Tree, tree},
     },
     text::Shaping,
 };
@@ -89,7 +88,7 @@ where
 
     #[inline]
     fn layout(
-        &self,
+        &mut self,
         _tree: &mut Tree,
         _renderer: &Renderer,
         limits: &iced_widget::core::layout::Limits,
@@ -114,36 +113,32 @@ where
     }
 
     #[inline]
-    fn on_event(
+    fn update(
         &mut self,
         tree: &mut Tree,
-        event: iced_widget::core::Event,
+        event: &iced_graphics::core::Event,
         layout: Layout<'_>,
         cursor: Cursor,
         _renderer: &Renderer,
         _clipboard: &mut dyn iced_widget::core::Clipboard,
         shell: &mut Shell<'_, Message>,
         _rectangle: &Rectangle,
-    ) -> event::Status {
+    ) {
         let bounds = layout.bounds();
-        let canvas_event = match event {
-            iced_widget::core::Event::Mouse(mouse_event) => Some(Event::Mouse(mouse_event)),
-            iced_widget::core::Event::Keyboard(keyboard_event) => {
-                Some(Event::Keyboard(keyboard_event))
-            }
-            _ => None,
+        let canvas_event = if matches!(event, Event::Mouse(_) | Event::Keyboard(_)) {
+            Some(event)
+        } else {
+            None
         };
         if let Some(canvas_event) = canvas_event {
             let state = tree.state.downcast_mut::<C::State>();
 
-            let (event_status, message) = self.chart.update(state, canvas_event, bounds, cursor);
+            let message = self.chart.update(state, canvas_event, bounds, cursor);
 
             if let Some(message) = message {
                 shell.publish(message);
             }
-            return event_status;
         }
-        event::Status::Ignored
     }
 
     fn mouse_interaction(

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -135,7 +135,7 @@ where
 
             let message = self.chart.update(state, canvas_event, bounds, cursor);
 
-            if let Some(message) = message {
+            if let (_, Some(message)) = message {
                 shell.publish(message);
             }
         }

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -43,32 +43,35 @@ where
             chart,
             width: Length::Fill,
             height: Length::Fill,
-            shaping: Default::default(),
-            _marker: Default::default(),
+            shaping: Shaping::default(),
+            _marker: PhantomData,
         }
     }
 
     /// set width
+    #[must_use]
     pub fn width(mut self, width: Length) -> Self {
         self.width = width;
         self
     }
 
     /// set height
+    #[must_use]
     pub fn height(mut self, height: Length) -> Self {
         self.height = height;
         self
     }
 
     /// set text shaping
+    #[must_use]
     pub fn text_shaping(mut self, shaping: Shaping) -> Self {
         self.shaping = shaping;
         self
     }
 }
 
-impl<'a, Message, Theme, Renderer, C> Widget<Message, Theme, Renderer>
-    for ChartWidget<'a, Message, Theme, Renderer, C>
+impl<Message, Theme, Renderer, C> Widget<Message, Theme, Renderer>
+    for ChartWidget<'_, Message, Theme, Renderer, C>
 where
     C: Chart<Message>,
     Renderer: self::Renderer,

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -136,9 +136,7 @@ where
         if let Some(canvas_event) = canvas_event {
             let state = tree.state.downcast_mut::<C::State>();
 
-            let message = self.chart.update(state, canvas_event, bounds, cursor);
-
-            if let (_, Some(message)) = message {
+            if let (_, Some(message)) = self.chart.update(state, canvas_event, bounds, cursor) {
                 shell.publish(message);
             }
         }


### PR DESCRIPTION
Migrate to Rust 2024 and to iced 0.14.

@Joylei with the 2024 edition of Rust, [static mutable refs are unstable](https://doc.rust-lang.org/edition-guide/rust-2024/static-mut-references.html).

I had to use `#[allow(static_mut_refs)]` on method `style_to_font` if you want to take a closer look.

***

> [!NOTE]
>
> ### I've published `plotters-iced2` for you to use with the latest versions of iced, Since the maintainer of this library seems to be inactive on GitHub.
>
> ### Links: [GitHub](https://github.com/GyulyVGC/plotters-iced2) | [Crates](https://crates.io/crates/plotters-iced2)